### PR TITLE
Add generic function variants for cases when the language is set at runtime

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,18 @@ import { getPartyFontColorDE as getPartyFontColor } from 'swiss-party-colors'
 import { getPartyFontColorOnBlackDE as getPartyFontColorOnBlack } from 'swiss-party-colors'
 ```
 
-#### `getParty(abbreviation)`
+or use the generic version, in cases where the language is set on runtime:
+
+```
+import { getParty } from 'swiss-party-colors'
+import { getPartyName } from 'swiss-party-colors'
+import { getPartyColor } from 'swiss-party-colors'
+import { getBlackOrWhite } from 'swiss-party-colors'
+import { getPartyFontColor } from 'swiss-party-colors'
+import { getPartyFontColorOnBlack } from 'swiss-party-colors'
+```
+
+#### `getParty(abbreviation)` (generic: `getParty(language, abbreviation)`)
 
 Returns an object for a given party abbreviation with the following properties:
 
@@ -66,23 +77,23 @@ Returns an object for a given party abbreviation with the following properties:
 - `fontColor`: the font color as a hex code
 - `fontColorOnBlack`: the font color for dark backgrounds as a hex code
 
-#### `getPartyName(abbreviation)`
+#### `getPartyName(abbreviation)` (generic: `getPartyName(language, abbreviation)`)
 
 Returns the full party name for a given party abbreviation
 
-#### `getPartyColor(abbreviation)`
+#### `getPartyColor(abbreviation)` (generic: `getPartyColor(language, abbreviation)`)
 
 Returns the the main color as a hex code for a given party abbreviation
 
-#### `getBlackOrWhite(abbreviation)`
+#### `getBlackOrWhite(abbreviation)` (generic: `getBlackOrWhite(language, abbreviation)`)
 
 Returns black or white as a hex code for a given party abbreviation
 
-#### `getPartyFontColor(abbreviation)`
+#### `getPartyFontColor(abbreviation)` (generic: `getPartyFontColor(laguage, abbreviation)`)
 
 Returns the font color as a hex code for a given party abbreviation
 
-#### `getPartyFontColorOnBlack(abbreviation)`
+#### `getPartyFontColorOnBlack(abbreviation)` (generic: `getPartyFontColorOnBlack(language, abbreviation)`)
 
 Returns the font color for dark backgrounds as a hex code for a given party abbreviation
 

--- a/index.js
+++ b/index.js
@@ -7,10 +7,31 @@
 })(this, function (exports) {
   'use strict'
 
+  /**
+   * The available languages
+   * @typedef {'de' | 'fr' | 'it'} LanguageCodes
+   */
+
+  /**
+   * The Party definition object
+   * @typedef {Object} PartyDefinition
+   * @property {string} abbr - The commonly used abbrevation of the party
+   * @property {string} name - The official name of the party
+   * @property {string} color - The color for use on larger color patches
+   * @property {string} blackOrWhite - The color for the text displayed on patches of that color
+   * @property {string} fontColor - A tweaked version of the color for use as a text color on light backgrounds
+   * @property {string} fontColorOnBlack - A tweaked version of the color for use as a text color on dark backgrounds
+   */
+
   var colors = require('./definitions.json')
 
+  /** @type {LanguageCodes[]} */
   var available_languages = [ 'de', 'fr', 'it' ]
 
+  /**
+   * Fallback object in cases where the party can't be found for some reason
+   * @type {PartyDefinition}
+   */
   var fallBackColor = {
     abbr: '?',
     name: 'Not found',
@@ -22,7 +43,8 @@
 
   /**
    * This function returns another function that can be used directly without defining the language code again
-   * @param {string} lang language code, either 'de', 'fr' or 'it'
+   * @param {LanguageCodes} lang language code, either 'de', 'fr' or 'it'
+   * @return {Function}
    */
   function getPartyFunctionForLanguage (lang) {
     lang = lang.toLowerCase()
@@ -52,10 +74,29 @@
     }
   }
 
+  /**
+   *
+   * @param {LanguageCodes} lang
+   * @param {string} abbr
+   * @return {PartyDefinition}
+   */
+  var getParty = (lang, abbr) => getPartyFunctionForLanguage(lang)(abbr)
+
   // create one function per language for export
   var getPartyDE = getPartyFunctionForLanguage('de')
   var getPartyFR = getPartyFunctionForLanguage('fr')
   var getPartyIT = getPartyFunctionForLanguage('it')
+
+  /**
+   * Get party name, using the specified language
+   * @param lang {LanguageCodes}
+   * @param abbr {string}
+   * @return {string}
+   */
+  function getPartyName(lang, abbr) {
+    var party = getPartyFunctionForLanguage(lang)(abbr)
+    if (party) return party.name
+  }
 
   function getPartyNameDE (abbr) {
     var party = getPartyDE(abbr)
@@ -70,6 +111,17 @@
   function getPartyNameIT (abbr) {
     var party = getPartyIT(abbr)
     if (party) return party.name
+  }
+
+  /**
+   * Get the party color, using the specified language
+   * @param lang {LanguageCodes}
+   * @param abbr {string}
+   * @return {string}
+   */
+  function getPartyColor(lang, abbr) {
+    var party = getPartyFunctionForLanguage(lang)(abbr)
+    if (party) return party.color
   }
 
   function getPartyColorDE (abbr) {
@@ -87,6 +139,16 @@
     if (party) return party.color
   }
 
+  /**
+   * Return whether the text on the coloured background should be black or white, according to accessibility standards.
+   * @param lang {LanguageCodes}
+   * @param abbr {string}
+   * @return {string}
+   */
+  function getBlackOrWhite (lang, abbr) {
+    var party = getPartyFunctionForLanguage(lang)(abbr)
+    if (party) return party.blackOrWhite
+  }
   function getBlackOrWhiteDE (abbr) {
     var party = getPartyDE(abbr)
     if (party) return party.blackOrWhite
@@ -100,6 +162,17 @@
   function getBlackOrWhiteIT (abbr) {
     var party = getPartyIT(abbr)
     if (party) return party.blackOrWhite
+  }
+
+  /**
+   * Return the party color for use as text color
+   * @param lang {LanguageCodes}
+   * @param abbr {string}
+   * @return {string}
+   */
+  function getPartyFontColor (lang, abbr) {
+    var party = getPartyFunctionForLanguage(lang)(abbr)
+    if (party) return party.fontColor
   }
 
   function getPartyFontColorDE (abbr) {
@@ -117,6 +190,17 @@
     if (party) return party.fontColor
   }
 
+  /**
+   * Return the party color for use as a text color on a dark background.
+   * @param lang {LanguageCodes}
+   * @param abbr {string}
+   * @return {string}
+   */
+  function getPartyFontColorOnBlack (lang, abbr) {
+    var party = getPartyFunctionForLanguage(lang)(abbr)
+    if (party) return party.fontColorOnBlack
+  }
+
   function getPartyFontColorOnBlackDE (abbr) {
     var party = getPartyDE(abbr)
     if (party) return party.fontColorOnBlack
@@ -132,26 +216,32 @@
     if (party) return party.fontColorOnBlack
   }
 
+  exports.getParty = getParty
   exports.getPartyDE = getPartyDE
   exports.getPartyFR = getPartyFR
   exports.getPartyIT = getPartyIT
 
+  exports.getPartyName = getPartyName
   exports.getPartyNameDE = getPartyNameDE
   exports.getPartyNameFR = getPartyNameFR
   exports.getPartyNameIT = getPartyNameIT
 
+  exports.getPartyColor = getPartyColor
   exports.getPartyColorDE = getPartyColorDE
   exports.getPartyColorFR = getPartyColorFR
   exports.getPartyColorIT = getPartyColorIT
 
+  exports.getBlackOrWhite = getBlackOrWhite
   exports.getBlackOrWhiteDE = getBlackOrWhiteDE
   exports.getBlackOrWhiteFR = getBlackOrWhiteFR
   exports.getBlackOrWhiteIT = getBlackOrWhiteIT
 
+  exports.getPartyFontColor = getPartyFontColor
   exports.getPartyFontColorDE = getPartyFontColorDE
   exports.getPartyFontColorFR = getPartyFontColorFR
   exports.getPartyFontColorIT = getPartyFontColorIT
 
+  exports.getPartyFontColorOnBlack = getPartyFontColorOnBlack
   exports.getPartyFontColorOnBlackDE = getPartyFontColorOnBlackDE
   exports.getPartyFontColorOnBlackFR = getPartyFontColorOnBlackFR
   exports.getPartyFontColorOnBlackIT = getPartyFontColorOnBlackIT

--- a/index.test.js
+++ b/index.test.js
@@ -117,3 +117,58 @@ bigSeven.forEach(party => {
     expect(getPartyFontColorOnBlackIT(party.abbr_it)).toBe(party.on_black)
   })
 })
+
+// region Test Generic, language-independent functions
+
+const getParty = require('./index').getParty
+const getPartyName = require('./index').getPartyName
+const getPartyColor = require('./index').getPartyColor
+const getBlackOrWhite = require('./index').getBlackOrWhite
+const getPartyFontColor = require('./index').getPartyFontColor
+const getPartyFontColorOnBlack = require('./index').getPartyFontColorOnBlack
+
+describe.each(bigSeven.map(party => ([party.abbr_de, party])))(
+  'Get properties for %p',
+  (partyAbbreviation, party) => {
+    describe.each(langCodes)(
+      'In %p',
+      (language) => {
+        test('getParty() returns correct party definition object', () => {
+          const partyDefinition = getParty(language, party['abbr_' + language])
+          expect(partyDefinition).toHaveProperty('name', party['name_' + language])
+          expect(partyDefinition).toHaveProperty('abbr', party['abbr_' + language])
+          expect(partyDefinition).toHaveProperty('color', party.color)
+          expect(partyDefinition).toHaveProperty('blackOrWhite', party.on_color)
+          expect(partyDefinition).toHaveProperty('fontColor', party.on_white)
+          expect(partyDefinition).toHaveProperty('fontColorOnBlack', party.on_black)
+        })
+
+        test('getPartyName() returns correct party name', () => {
+          const partyName = getPartyName(language, party['abbr_' + language])
+          expect(partyName).toBe(party['name_' + language])
+        })
+
+        test('getPartyColor() returns correct color', () => {
+          const partyColor = getPartyColor(language, party['abbr_' + language])
+          expect(partyColor).toBe(party.color)
+        })
+
+        test('getBlackOrWhite() returns correct color', () => {
+          const blackOrWhite = getBlackOrWhite(language, party['abbr_' + language])
+          expect(blackOrWhite).toBe(party.on_color)
+        })
+
+        test('getPartyFontColor() returns correct color', () => {
+          const fontColor = getPartyFontColor(language, party['abbr_' + language])
+          expect(fontColor).toBe(party.on_white)
+        })
+
+        test('getPartyFontColorOnBlack() returns correct color', () => {
+          const fontColor = getPartyFontColorOnBlack(language, party['abbr_' + language])
+          expect(fontColor).toBe(party.on_black)
+        })
+      }
+    )
+  })
+
+// endregion


### PR DESCRIPTION
… as it says in the title.

In our team we create our standalones to switch between languages on runtime, so these changes would come in handy.